### PR TITLE
Fix NameError for get_all_tags

### DIFF
--- a/credential_manager.py
+++ b/credential_manager.py
@@ -3,7 +3,7 @@ import pandas as pd
 import secrets
 import string
 from database import (
-    get_all_credentials, insert_credential, update_credential, delete_credential
+    get_all_credentials, insert_credential, update_credential, delete_credential, get_all_tags
 )
 from encryption import retrieve_secure, secure_store
 from st_copy import copy_button


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because the `get_all_tags` function was not imported in `credential_manager.py`.

The following changes were made:
-   Updated the import statement in `credential_manager.py` to include `get_all_tags` from `database.py`.